### PR TITLE
ファイルを開くコマンドを指定できるようにした

### DIFF
--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -170,7 +170,7 @@ function! hateblo#detailEntry(entry_url)
         \ g:hateblo_vim['api_key']
         \ )
   let l:escaped_entry_title = substitute(l:entry['title'], ' ', '\\ ', 'g')
-  execute 'edit' l:escaped_entry_title
+  execute g:hateblo_vim['edit_command'] . l:escaped_entry_title
 
   if exists("g:hateblo_vim['WYSIWYG_mode']") && g:hateblo_vim['WYSIWYG_mode'] == 1
     let l:lines = substitute(l:lines, '<br />', '\n', 'g')

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -16,7 +16,10 @@ set cpo&vim
 " - g:hateblo_vim['api_endpoint']   Endpoint of API
 " - g:hateblo_vim['WYSIWYG_mode']   ( 0 | 1 )
 " - g:hateblo_vim['always_yes']     ( 0 | 1 )
+
 source $HOME/.hateblo.vim
+
+let g:hateblo_vim['edit_command'] = get(g:hateblo_vim, 'edit_command', 'edit')
 
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')


### PR DESCRIPTION
`g:heteblo_vim` に `'edit_command'` というキーを追加して, ファイルを開く際のコマンドを指定できるように変更しました.
指定しない場合はデフォルトで 'edit' が代入されるようにしています.
