### PR TITLE
Metarw化

### DIFF
--- a/autoload/metarw/hateblo.vim
+++ b/autoload/metarw/hateblo.vim
@@ -1,0 +1,54 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:entry_api = g:hateblo_vim['api_endpoint'] . '/entry'
+let s:metarw_head = 'hateblo:'
+let s:new_entry_id = 'NewEntry'
+
+function! metarw#hateblo#read(fakepath)
+  let l:entry_id = substitute(a:fakepath, s:metarw_head, '', '')
+  if l:entry_id == "" || l:entry_id[0] == "?"
+    let l:feed = hateblo#getFeed(s:entry_api . l:entry_id)
+    let l:entries = map(l:feed['entry'], '{
+          \ "label": v:val["title"],
+          \ "fakepath": s:metarw_head . hateblo#getEntryID(v:val["link"][0]["href"])
+          \ }')
+
+    call insert(l:entries, {
+          \ 'label': 'New Entry',
+          \ 'fakepath': s:metarw_head . s:new_entry_id
+          \ }, 0)
+
+    let l:next_page = hateblo#getNextPageLink(l:feed)
+    if l:next_page != ""
+      call add(l:entries, {
+            \ 'label': '   Next Page  >',
+            \ 'fakepath': s:metarw_head . substitute(l:next_page, s:entry_api, '', '')
+            \ })
+    endif
+
+    let l:first_page = hateblo#getFirstPageLink(l:feed)
+    if l:first_page != ""
+      call add(l:entries, {
+            \ 'label': '<< First Page',
+            \ 'fakepath': s:metarw_head . substitute(l:first_page, s:entry_api, '', '')
+            \ })
+    endif
+    return ['browse', l:entries]
+  endif
+  if l:entry_id ==# s:new_entry_id
+    let l:entry_id = hateblo#newEntry()
+    execute ':file ' . s:metarw_head . l:entry_id
+  endif
+  call hateblo#readEntry(s:entry_api . '/' . l:entry_id)
+  return ['done', '']
+endfunction
+
+function! metarw#hateblo#write(fakepath, l1, l2, append_p)
+  " call hateblo#updateEntry(1)
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set ts=2 tw=2 sw=2:

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -38,7 +38,7 @@ let g:hateblo_vim['edit_command'] = get(g:hateblo_vim, 'edit_command', 'edit')
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')
 command! -nargs=0 HatebloList        call hateblo#listEntry()
-command! -nargs=? HatebloUpdate      call hateblo#updateEntry(<f-args>)
+command! -nargs=0 HatebloUpdate      call hateblo#updateEntry(0)
 command! -nargs=0 HatebloDelete      call hateblo#deleteEntry()
 
 let g:loaded_hateblo = 1


### PR DESCRIPTION
一覧して編集する、といった作業はunite.vimよりも
vim-metarwとの相性がいいと思うので、実装しました。

変更点は以下の2点です。
- `autoload/hateblo.vim`全体のリファクタリング(重複部分の関数化)
- `autoload/metarw/hateblo.vim`の追加

命名規則、コーディングスタイル等、指摘していだだければ修正します。
必要であればリクエストを分割します。
## 使用法

```
:e hateblo:
```

で一覧を取得、metarwのブラウザで一覧表示。
編集したい記事名上でEnterを押せば編集できます。
`:w`でセーブするたびに投稿します。

考えを聞かせて下さい。
