### PR TITLE
Bug fixes for metarw mode

### DIFF
--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -1,8 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let g:hateblo_entry_api_endpoint = g:hateblo_vim['api_endpoint'] . '/entry'
-
 function! hateblo#createEntry(is_draft)
   let b:hateblo_contents_beginning_line = 1 " XXX suxxs!
 

--- a/autoload/metarw/hateblo.vim
+++ b/autoload/metarw/hateblo.vim
@@ -8,7 +8,7 @@ let s:new_entry_id = 'NewEntry'
 function! metarw#hateblo#read(fakepath)
   let l:entry_id = substitute(a:fakepath, s:metarw_head, '', '')
   if l:entry_id == "" || l:entry_id[0] == "?"
-    let l:feed = hateblo#getFeed(s:entry_api . l:entry_id)
+    let l:feed = hateblo#webapi#getFeed(s:entry_api . l:entry_id)
     let l:entries = map(l:feed['entry'], '{
           \ "label": v:val["title"],
           \ "fakepath": s:metarw_head . s:getEntryID(v:val["link"][0]["href"])
@@ -57,7 +57,7 @@ function! s:getFirstPageLink(feed)
 endfunction
 
 function! s:newEntry()
-  let l:entry_url = util#hateblo#createEntry('', '', [], 'yes')
+  let l:entry_url = hateblo#webapi#createEntry('', '', [],'yes')
   return s:getEntryID(l:entry_url)
 endfunction
 

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -34,6 +34,7 @@ set cpo&vim
 " - g:hateblo_vim['edit_command']   Command to open the entry
 
 let g:hateblo_vim['edit_command'] = get(g:hateblo_vim, 'edit_command', 'edit')
+let g:hateblo_entry_api_endpoint = g:hateblo_vim['api_endpoint'] . '/entry'
 
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')


### PR DESCRIPTION
前回のリクエストにバグが多くて申し訳ありません。
現在のmasterでmetarwモードが起動できないバグを修正しました。

`:e hateblo:`とした場合、`autoload/hateblo.vim`を一度も読み込まないまま
`autoload/metarw/hateblo.vim`を読み込むので`g:hateblo_entry_api_endpoint`が定義されません。
ですので`plugin/hateblo.vim`側で定義しました。
また名前空間の変更が反映されていない部分を修正しました。

確認お願いします。
