### PR TITLE
Enable to call :Unite hateblo-list

### DIFF
--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -72,16 +72,6 @@ function! hateblo#detailEntry(entry_url)
   call s:save_entry_meta_to_buffer(a:entry_url, l:entry)
 endfunction
 
-function! hateblo#listEntry(...)
-  if exists('a:000[0]')
-    let l:feed = hateblo#webapi#getFeed(a:000[0])
-  else
-    let l:feed = hateblo#webapi#getFeed(g:hateblo_entry_api_endpoint)
-  endif
-  call s:save_feed_meta_to_buffer(l:feed)
-  Unite hateblo-list
-endfunction
-
 function! hateblo#getNextPageLink(feed)
   for l:link in a:feed['link']
     if l:link['rel'] == 'next'
@@ -197,11 +187,6 @@ function! s:save_entry_meta_to_buffer(entry_url, entry)
   let b:hateblo_entry_title = a:entry['title']
   let b:hateblo_is_draft = a:entry['app:control']['app:draft']
   execute 'setlocal filetype=' . s:get_content_type(a:entry)
-endfunction
-
-function! s:save_feed_meta_to_buffer(feed)
-  let b:hateblo_entries = a:feed['entry']
-  let b:hateblo_next_page = hateblo#getNextPageLink(a:feed)
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/unite/sources/hateblo_list.vim
+++ b/autoload/unite/sources/hateblo_list.vim
@@ -20,11 +20,15 @@ function! s:unite_hateblo_list_source.action_table.on_choose.func(candidate)
   if a:candidate.action__action == 'edit_entry'
     call hateblo#detailEntry(a:candidate.action__url)
   elseif a:candidate.action__action == 'next_page'
-    call hateblo#listEntry(a:candidate.action__url)
+    call s:getFeed(a:candidate.action__url)
+    Unite hateblo-list
   endif
 endfunction
 
 function! s:unite_hateblo_list_source.gather_candidates(args, context)
+  if !exists('b:hateblo_entries')
+    call s:getFeed()
+  endif
   let l:entries = b:hateblo_entries
 
   let l:entry_list = []
@@ -61,6 +65,16 @@ endfunction
 
 function! unite#sources#hateblo_list#define()
   return s:unite_hateblo_list_source
+endfunction
+
+function! s:getFeed(...)
+  if exists('a:000[0]')
+    let l:feed = hateblo#webapi#getFeed(a:000[0])
+  else
+    let l:feed = hateblo#webapi#getFeed(g:hateblo_entry_api_endpoint)
+  endif
+  let b:hateblo_entries = l:feed['entry']
+  let b:hateblo_next_page = hateblo#getNextPageLink(l:feed)
 endfunction
 
 let &cpo = s:save_cpo

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -38,7 +38,7 @@ let g:hateblo_entry_api_endpoint = g:hateblo_vim['api_endpoint'] . '/entry'
 
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')
-command! -nargs=0 HatebloList        call hateblo#listEntry()
+command! -nargs=0 HatebloList        Unite hateblo-list
 command! -nargs=0 HatebloUpdate      call hateblo#updateEntry()
 command! -nargs=0 HatebloDelete      call hateblo#deleteEntry()
 


### PR DESCRIPTION
About #31

I move `hateblo#listEntry(...)` into `s:getFeed(...)` on unite/source/hateblo.vim
to enable calling `:Unite hateblo-list` alone.

Then `:HatebloList` becomes an alias to `:Unite hateblo-list`.
