### PR TITLE
Autosave

### DIFF
--- a/autoload/hateblo/lines.vim
+++ b/autoload/hateblo/lines.vim
@@ -1,0 +1,60 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! hateblo#lines#analyse(lines)
+  let result = {}
+  let header_position = 0
+
+  let title_line = a:lines[header_position]
+  let title_top = stridx(title_line, g:hateblo_title_prefix)
+  if title_top >= 0
+    let result['title_line'] = header_position
+    let result['title'] = hateblo#string#strip_whitespace(
+          \ title_line[title_top + len(g:hateblo_title_prefix):])
+    let header_position += 1
+  endif
+
+  let category_line = a:lines[header_position]
+  let category_top = stridx(category_line, g:hateblo_category_prefix)
+  if category_top >= 0
+    let result['category_line'] = header_position
+    let category_str = hateblo#string#strip_whitespace(
+          \ category_line[category_top + len(g:hateblo_category_prefix) :])
+    let result['category'] = map(split(category_str, ','), 
+                                 \ 'hateblo#string#strip_whitespace(v:val)')
+    let header_position += 1
+  endif
+
+  return result
+endfunction
+
+function! hateblo#lines#format(lines)
+  let l:lines = a:lines
+  if exists("g:hateblo_vim['WYSIWYG_mode']") && g:hateblo_vim['WYSIWYG_mode'] == 1
+    let l:lines = map(l:lines, 'substitute(v:val, "<br />", "\n", "g")')
+  endif
+  let l:lines = map(l:lines, 'substitute(v:val, "$", "", "")') " Remove 'CR' newline characters
+  return l:lines
+endfunction
+
+function! hateblo#lines#parse(lines)
+  let result = {}
+  let res = hateblo#lines#analyse(a:lines)
+
+  " あるとすればタイトル、カテゴリの順と仮定する
+  if has_key(res, 'category_line') && has_key(res, 'category')
+    call remove(a:lines, res['category_line'])
+    let result['category'] = res['category']
+  endif
+  if has_key(res, 'title_line') && has_key(res, 'title')
+    call remove(a:lines, res['title_line'])
+    let result['title'] = res['title']
+  endif
+  let result['contents'] = join(hateblo#lines#format(a:lines), '\n')
+  return result
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set tw=2 ts=2 sw=2:

--- a/autoload/metarw/hateblo.vim
+++ b/autoload/metarw/hateblo.vim
@@ -41,11 +41,29 @@ function! metarw#hateblo#read(fakepath)
     execute ':file ' . s:metarw_head . l:entry_id
   endif
   call hateblo#readEntry(s:entry_api . '/' . l:entry_id)
+  let b:hateblo_metarw_save_flag = 0
   return ['done', '']
 endfunction
 
 function! metarw#hateblo#write(fakepath, l1, l2, append_p)
-  " call hateblo#updateEntry(1)
+  let b:hateblo_metarw_save_flag = 1
+endfunction
+
+function! metarw#hateblo#autosave()
+  let buf_num = str2nr(expand("<abuf>"))
+  let save_flag = getbufvar(buf_num, 'hateblo_metarw_save_flag')
+  if save_flag == 1
+    let lines = getbufline(buf_num, 1, '$')
+    let detail = hateblo#lines#parse(lines)
+    echo 'Sending article...'
+    call hateblo#webapi#updateEntry(
+          \ getbufvar(buf_num, 'hateblo_entry_url'),
+          \ detail['title'],
+          \ detail['contents'],
+          \ detail['category'],
+          \ getbufvar(buf_num, 'hateblo_is_draft'))
+    echo 'Done'
+  endif
 endfunction
 
 function! s:getFirstPageLink(feed)

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -36,11 +36,19 @@ set cpo&vim
 let g:hateblo_vim['edit_command'] = get(g:hateblo_vim, 'edit_command', 'edit')
 let g:hateblo_entry_api_endpoint = g:hateblo_vim['api_endpoint'] . '/entry'
 
+let g:hateblo_title_prefix = 'TITLE:'
+let g:hateblo_category_prefix = 'CATEGORY:'
+
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')
 command! -nargs=0 HatebloList        call hateblo#listEntry()
 command! -nargs=0 HatebloUpdate      call hateblo#updateEntry()
 command! -nargs=0 HatebloDelete      call hateblo#deleteEntry()
+
+augroup hateblo_metarw_autosave
+  autocmd!
+  autocmd BufUnload hateblo:[0-9]* call metarw#hateblo#autosave()
+augroup END
 
 let g:loaded_hateblo = 1
 


### PR DESCRIPTION
#27 で断念した自動保存機能を実装しました。
1. metarwモードで記事を開く
2. `:w`等で保存する（フラグが立つ）
3. `BufUnload`時に自動的に送信する。

のように動作します。
metarw以外で開いた場合は無効です。一度も保存せずにバッファを廃棄する場合も無効です。
これなら大量のリクエストを送りません。

下書きかどうかはバッファに保管されいる値(`b:hateblo_is_draft`)を使用します。
公開する場合は`:HatebloUpdate`で明示的に更新します。

`BufUnload`を使用するため、`getline`等の関数の代りに`getbufline`を使用する必要があり、
タイトル、カテゴリのパース部分をバッファに依存しない形で新たに実装しました(`hateblo#lines#*`)。
ただし`hateblo#lines#format`は`s:format_lines`の完全な移植です。
