### PR TITLE
自動保存時の改行の扱い

### DIFF
--- a/autoload/hateblo/lines.vim
+++ b/autoload/hateblo/lines.vim
@@ -50,7 +50,7 @@ function! hateblo#lines#parse(lines)
     call remove(a:lines, res['title_line'])
     let result['title'] = res['title']
   endif
-  let result['contents'] = join(hateblo#lines#format(a:lines), '\n')
+  let result['contents'] = join(hateblo#lines#format(a:lines), "\n")
   return result
 endfunction
 


### PR DESCRIPTION
自動保存による更新時における、
改行の扱いのバグを修正しました。

''内は特殊文字が無効になるので""に変更しました。
