### PR TITLE
config設定およびタイトル, カテゴリの変更を容易にしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Provided commands
 現在のバッファのエントリを削除します．
 上述の方法で開いたバッファでしか実行できません．
 
+Configuration
+------------
+.hateblo.vimの位置、blogのentryの保存位置などを指定できます.
+```vim
+NeoBundle 'TKNGUE/hateblo.vim' ,{
+            \ 'depends'  : ['mattn/webapi-vim', 'Shoug/unite.vim'],
+            \}
+let g:hateblo_config_path = '$HOME/.hateblo/.hateblo.vim'
+let g:hateblo_dir = '$HOME/.hateblo/blog'
+```
+
 Dependencies
 ------------
 

--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -75,7 +75,9 @@ function! hateblo#detailEntry(entry_url)
 
   let l:lines = s:get_lines(l:entry)
   silent! normal ggdG
-  call append(0, l:lines)
+  call append(1, l:lines)
+  call append(0, s:title_prefix . l:entry['title'])
+  call append(1, s:category_prefix . join(s:get_entry_category(l:entry), ', '))
   call s:save_entry_meta_to_buffer(a:entry_url, l:entry)
 endfunction
 

--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -66,7 +66,9 @@ endfunction
 function! hateblo#detailEntry(entry_url)
   let l:entry = hateblo#webapi#getEntry(a:entry_url)
   let l:escaped_entry_title = hateblo#string#escape_space(l:entry['title'])
-  execute g:hateblo_vim['edit_command'] . hateblo#string#prepend_space(l:escaped_entry_title)
+  execute g:hateblo_vim['edit_command'] 
+        \ . hateblo#string#prepend_space(g:hateblo_dir) 
+        \. hateblo#string#prepend_space(l:escaped_entry_title)
   let l:lines = s:get_lines(l:entry)
   call append(0, l:lines)
   call s:save_entry_meta_to_buffer(a:entry_url, l:entry)

--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -74,6 +74,7 @@ function! hateblo#detailEntry(entry_url)
         \ .'/'. l:escaped_entry_title
 
   let l:lines = s:get_lines(l:entry)
+  silent! normal ggdG
   call append(0, l:lines)
   call s:save_entry_meta_to_buffer(a:entry_url, l:entry)
 endfunction

--- a/autoload/hateblo.vim
+++ b/autoload/hateblo.vim
@@ -9,6 +9,9 @@ function! hateblo#createEntry(is_draft)
   let l:lines    = s:format_lines(getline(b:hateblo_contents_beginning_line, '$'))
   let l:content  = join(l:lines, "\n")
 
+  let l:escaped_entry_title = hateblo#string#escape_space(l:title)
+  execute  "write ". hateblo#string#prepend_space( g:hateblo_dir ) . '/'. l:escaped_entry_title
+
   if s:ask('Post?')
     call hateblo#webapi#createEntry(l:title, l:content, l:category, a:is_draft)
     redraw
@@ -67,8 +70,9 @@ function! hateblo#detailEntry(entry_url)
   let l:entry = hateblo#webapi#getEntry(a:entry_url)
   let l:escaped_entry_title = hateblo#string#escape_space(l:entry['title'])
   execute g:hateblo_vim['edit_command'] 
-        \ . hateblo#string#prepend_space(g:hateblo_dir) 
-        \. hateblo#string#prepend_space(l:escaped_entry_title)
+        \. hateblo#string#prepend_space(g:hateblo_dir) 
+        \ .'/'. l:escaped_entry_title
+
   let l:lines = s:get_lines(l:entry)
   call append(0, l:lines)
   call s:save_entry_meta_to_buffer(a:entry_url, l:entry)

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -11,34 +11,41 @@ if exists('g:loaded_hateblo')
   finish
 endif
 
+if !exists('g:hateblo_dir')
+    let g:hateblo_dir = expand("$HOME/.hateblo/blog")
+else 
+    let g:hateblo_dir = expand(g:hateblo_dir)
+endif
+
+if !isdirectory(g:hateblo_dir) 
+    if (input(printf('"%s" does not exist. Create? [y/N]', g:hateblo_dir)) =~? '^y\%[es]$')
+        call mkdir(iconv(g:hateblo_dir, &encoding, &termencoding), 'p')
+    else 
+        let g:hateblo_dir = expand("./")
+    endif
+endif
+
+if !exists('g:hateblo_config_path')
+    let g:hateblo_config_path =expand("$HOME/.hateblo.vim")
+else  
+    let g:hateblo_config_path = expand(g:hateblo_config_path)
+endif
+
+if filereadable(g:hateblo_config_path)
+  execute "source " . g:hateblo_config_path
+endif
+
+if !exists('g:hateblo_vim')
+  finish
+endif
+
 
 "Recommended Global Configuration
 " let g:hateblo_config_path = '$HOME/.hateblo/.hateblo.vim'
 " let g:hateblo_dir = '$HOME/.hateblo/blog'
 " let g:hateblo_title_prefix = 'TITLE:'
 " let g:hateblo_category_prefix = 'CATEGORY:'
-
-if !exists('g:hateblo_dir')
-    let g:hateblo_dir = "$HOME/.hateblo/blog"
-    if !isdirectory(g:hateblo_dir) && (
-                \ input(printf('"%s" does not exist. Create? [y/N]', g:hateblo_dir)) =~? '^y\%[es]$')
-        call mkdir(iconv(g:hateblo_dir, &encoding, &termencoding), 'p')
-    else
-        let g:hateblo_dir = ""
-    endif
-
-if !exists('g:hateblo_config_path')
-    let g:hateblo_config_path = "$HOME/.hateblo.vim"
-endif
-
-if filereadable(g:hateblo_config_path)
-  source  g:hateblo_config_path
-endif
-if !exists('g:hateblo_vim')
-  finish
-endif
-
-
+"
 " This script expects the following variables in ~/.hateblo.vim
 " - g:hateblo_vim['user']           User ID
 " - g:hateblo_vim['api_key']        API Key

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -39,7 +39,6 @@ if !exists('g:hateblo_vim')
   finish
 endif
 
-
 "Recommended Global Configuration
 " let g:hateblo_config_path = '$HOME/.hateblo/.hateblo.vim'
 " let g:hateblo_dir = '$HOME/.hateblo/blog'
@@ -73,6 +72,7 @@ command! -nargs=0 HatebloDelete      call hateblo#deleteEntry()
 augroup hateblo_metarw_autosave
   autocmd!
   autocmd BufUnload hateblo:[0-9]* call metarw#hateblo#autosave()
+  execute "autocmd BufRead ".  g:hateblo_dir. "/* set ft=markdown"
 augroup END
 
 let g:loaded_hateblo = 1

--- a/plugin/hateblo.vim
+++ b/plugin/hateblo.vim
@@ -1,29 +1,43 @@
 " This plugin provides some functions of Hetena-Blog by using AtomPub API
 " File: hateblo.vim
 " Author: moznion (Taiki Kawakami) <moznion@gmail.com>
+" Contributor:TKNGUE
 " License: MIT License
+
+let s:save_cpo = &cpo
+set cpo&vim
 
 if exists('g:loaded_hateblo')
   finish
 endif
 
-let s:config_file_exists = 1
-try
-  execute 'source $HOME/.hateblo.vim'
-catch
-  let s:config_file_exists = 0 " .hateblo.vim doesn't exist
-endtry
 
-if s:config_file_exists == 1
-  source $HOME/.hateblo.vim
+"Recommended Global Configuration
+" let g:hateblo_config_path = '$HOME/.hateblo/.hateblo.vim'
+" let g:hateblo_dir = '$HOME/.hateblo/blog'
+" let g:hateblo_title_prefix = 'TITLE:'
+" let g:hateblo_category_prefix = 'CATEGORY:'
+
+if !exists('g:hateblo_dir')
+    let g:hateblo_dir = "$HOME/.hateblo/blog"
+    if !isdirectory(g:hateblo_dir) && (
+                \ input(printf('"%s" does not exist. Create? [y/N]', g:hateblo_dir)) =~? '^y\%[es]$')
+        call mkdir(iconv(g:hateblo_dir, &encoding, &termencoding), 'p')
+    else
+        let g:hateblo_dir = ""
+    endif
+
+if !exists('g:hateblo_config_path')
+    let g:hateblo_config_path = "$HOME/.hateblo.vim"
 endif
 
+if filereadable(g:hateblo_config_path)
+  source  g:hateblo_config_path
+endif
 if !exists('g:hateblo_vim')
   finish
 endif
 
-let s:save_cpo = &cpo
-set cpo&vim
 
 " This script expects the following variables in ~/.hateblo.vim
 " - g:hateblo_vim['user']           User ID
@@ -36,8 +50,12 @@ set cpo&vim
 let g:hateblo_vim['edit_command'] = get(g:hateblo_vim, 'edit_command', 'edit')
 let g:hateblo_entry_api_endpoint = g:hateblo_vim['api_endpoint'] . '/entry'
 
-let g:hateblo_title_prefix = 'TITLE:'
-let g:hateblo_category_prefix = 'CATEGORY:'
+if !exists('g:hateblo_title_prefix')
+    let g:hateblo_title_prefix = 'TITLE:'
+endif
+if !exists('g:hateblo_category_prefix')
+    let g:hateblo_category_prefix = 'CATEGORY:'
+endif
 
 command! -nargs=0 HatebloCreate      call hateblo#createEntry('no')
 command! -nargs=0 HatebloCreateDraft call hateblo#createEntry('yes')
@@ -51,6 +69,5 @@ augroup hateblo_metarw_autosave
 augroup END
 
 let g:loaded_hateblo = 1
-
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
・変数(g:hateblo_config_path)でアカウント情報の所在を指定できるようにしました・
・変数(g:hateblo_dir)で記事の保存フォルダを決めれるようにしました.
・タイトルとカテゴリの変更を容易にしました.
